### PR TITLE
Add Moises.ai reference to Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ For a more detailed documentation, please check the [repository wiki](https://gi
 
 Want to try it out but don't want to install anything ? we've setup a [Google Colab](https://colab.research.google.com/github/deezer/spleeter/blob/master/spleeter.ipynb)
 
+Alternatively, you can also try Spleeter in the browser using the free service [Moises.ai](https://moises.ai).
+
 ## Reference
 
 


### PR DESCRIPTION
# [Spleeter-readme] - Add Moises.ai reference to Readme file

## Description

Moises.ai runs Spleeter in a farm of servers and allow anyone to try it without installing anything. You can post a song and get back separated tracks back (2stems, 4stems or 5stems supported).

## How this patch was tested

No test required.

## Documentation link and external references

Not applicable
